### PR TITLE
Update etc

### DIFF
--- a/app/src/main/java/com/example/hireapp/models/Comment.kt
+++ b/app/src/main/java/com/example/hireapp/models/Comment.kt
@@ -2,5 +2,7 @@ package com.example.hireapp.models
 
 data class Comment(
     val user: String = "",
+    val major: String = "",
+    val sub: String = "",
     val text: String = ""
 )

--- a/app/src/main/java/com/example/hireapp/navigation/Navigation.kt
+++ b/app/src/main/java/com/example/hireapp/navigation/Navigation.kt
@@ -2,6 +2,7 @@ package com.example.hireapp.navigation
 
 import android.util.Log
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -31,6 +32,8 @@ fun AppNavHost(navController: NavHostController = rememberNavController(), userT
         else -> Screen.Login.route  // 로그인 화면
     }
 
+    val sharedViewModel: SignUpModel = viewModel()
+
     Log.d("UserType", userType.toString())
     NavHost(
         navController = navController,
@@ -40,9 +43,11 @@ fun AppNavHost(navController: NavHostController = rememberNavController(), userT
         composable(Screen.SignUp.route) { SignUpScreen(navController) }
         composable(Screen.SignUpCommon.route + "/{role}") { backStackEntry ->
             val role = backStackEntry.arguments?.getString("role") ?: ""
-            SignUpCommonScreen(navController, role)
+            SignUpCommonScreen(navController, sharedViewModel, role)
         }
-        composable(Screen.SignUpInterviewer.route) { SignUpInterviewerScreen(navController) }
+        composable(Screen.SignUpInterviewer.route) {
+            SignUpInterviewerScreen(navController, sharedViewModel)
+        }
         composable(Screen.HomeAppl.route) { HomeApplScreen(navController) }
         composable(Screen.HomeIntr.route) { HomeIntrScreen(navController) }
         composable(Screen.MyPageAppl.route) { MyPageApplScreen(navController) }

--- a/app/src/main/java/com/example/hireapp/screens/VideoDetailScreen.kt
+++ b/app/src/main/java/com/example/hireapp/screens/VideoDetailScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
@@ -72,6 +71,8 @@ fun VideoDetailScreen(videoId: String, navController: NavController) {
     var comments = remember { mutableStateListOf<Comment>() }
     var inputText by remember { mutableStateOf("") }
     var currentUserName by remember { mutableStateOf("me") }
+    var currUserMajor by remember { mutableStateOf("지정 없음") }
+    var currUserSub by remember { mutableStateOf("지정 없음") }
     val listState = rememberLazyListState()
     val flingBehavior = rememberSnapFlingBehavior(lazyListState = listState)
 
@@ -82,6 +83,8 @@ fun VideoDetailScreen(videoId: String, navController: NavController) {
             db.collection("users").document(user.uid).get()
                 .addOnSuccessListener { doc ->
                     currentUserName = doc.getString("name") ?: "익명"
+                    currUserMajor = doc.getString("category.major") ?: "지정 없음"
+                    currUserSub = doc.getString("category.sub") ?: "지정 없음"
                 }
                 .addOnFailureListener {
                     Toast.makeText(context, "유저 정보를 불러올 수 없습니다.", Toast.LENGTH_SHORT).show()
@@ -146,8 +149,10 @@ fun VideoDetailScreen(videoId: String, navController: NavController) {
                     comments.clear()
                     for (doc in snapshot.documents) {
                         val user = doc.getString("user") ?: "익명"
+                        val major = doc.getString("category.major") ?: "지정 없음"
+                        val sub = doc.getString("category.sub") ?: "지정 없음"
                         val text = doc.getString("text") ?: ""
-                        comments.add(Comment(user, text))
+                        comments.add(Comment(user = user, major = major, sub = sub, text = text))
                     }
                 }
             }
@@ -280,9 +285,13 @@ fun VideoDetailScreen(videoId: String, navController: NavController) {
                         Spacer(modifier = Modifier.height(16.dp))
                     }
 
-                    itemsIndexed(comments) { index, comment ->
+                    itemsIndexed(comments) { _, comment ->
                         Column(modifier = Modifier.padding(vertical = 8.dp)) {
-                            Text(text = comment.user, fontWeight = FontWeight.Bold)
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(text = comment.user, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(text = "${comment.major} | ${comment.sub}", color = Color.Gray)
+                            }
                             Text(text = comment.text)
                         }
                     }
@@ -302,7 +311,7 @@ fun VideoDetailScreen(videoId: String, navController: NavController) {
                     )
                     IconButton(onClick = {
                         if (inputText.isNotBlank()) {
-                            val newComment = Comment(currentUserName, inputText)
+                            val newComment = Comment(currentUserName, currUserMajor, currUserSub, inputText)
                             coroutineScope.launch {
                                 try {
                                     db.collection("interview")
@@ -311,6 +320,8 @@ fun VideoDetailScreen(videoId: String, navController: NavController) {
                                         .add(mapOf(
                                             "user" to newComment.user,
                                             "text" to newComment.text,
+                                            "major" to newComment.major,
+                                            "sub" to newComment.sub,
                                             "timestamp" to System.currentTimeMillis()
                                         ))
                                     inputText = ""

--- a/app/src/main/java/com/example/hireapp/screens/VideoDetailScreen.kt
+++ b/app/src/main/java/com/example/hireapp/screens/VideoDetailScreen.kt
@@ -2,6 +2,7 @@ package com.example.hireapp.screens
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -83,8 +84,11 @@ fun VideoDetailScreen(videoId: String, navController: NavController) {
             db.collection("users").document(user.uid).get()
                 .addOnSuccessListener { doc ->
                     currentUserName = doc.getString("name") ?: "익명"
-                    currUserMajor = doc.getString("category.major") ?: "지정 없음"
-                    currUserSub = doc.getString("category.sub") ?: "지정 없음"
+                    val categoryMap = doc.get("category") as? Map<*, *>
+                    currUserMajor = categoryMap?.get("major") as? String ?: "지정 없음"
+                    currUserSub = categoryMap?.get("sub") as? String ?: "지정 없음"
+
+                    Log.d("Comment", "로그인한 유저 ㅅcategory: ${categoryMap}, ${currUserMajor}, ${currUserSub}")
                 }
                 .addOnFailureListener {
                     Toast.makeText(context, "유저 정보를 불러올 수 없습니다.", Toast.LENGTH_SHORT).show()
@@ -148,9 +152,9 @@ fun VideoDetailScreen(videoId: String, navController: NavController) {
                 if (snapshot != null) {
                     comments.clear()
                     for (doc in snapshot.documents) {
+                        val major = doc.getString("major") ?: "지정 없음"
+                        val sub = doc.getString("sub") ?: "지정 없음"
                         val user = doc.getString("user") ?: "익명"
-                        val major = doc.getString("category.major") ?: "지정 없음"
-                        val sub = doc.getString("category.sub") ?: "지정 없음"
                         val text = doc.getString("text") ?: ""
                         comments.add(Comment(user = user, major = major, sub = sub, text = text))
                     }

--- a/app/src/main/java/com/example/hireapp/screens/applicant/interviewcapture/CheckQuestionScreen.kt
+++ b/app/src/main/java/com/example/hireapp/screens/applicant/interviewcapture/CheckQuestionScreen.kt
@@ -6,6 +6,7 @@ import android.annotation.SuppressLint
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
@@ -46,6 +47,7 @@ import kotlinx.coroutines.tasks.await
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.hireapp.navigation.Screen
+import com.example.hireapp.util.LoadingState
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
 import com.google.firebase.auth.FirebaseAuth
@@ -434,17 +436,24 @@ fun CheckQuestionScreen(
                 },
                 confirmButton = {
                     TextButton(onClick = {
-                        uploadResults(
-                            db               = db,
-                            auth             = FirebaseAuth.getInstance(),
-                            sessionId        = sessionId,
-                            questions        = questions,
-                            videoTitle       = videoTitle,
-                            recordedFiles    = recordedFiles,
-                            navController    = navController
-                        )
                         showTitleDialog = false
-                        navController.navigate("${Screen.ResultScreen.route}/$sessionId")
+                        scope.launch {
+                            val result = uploadResults(
+                                db               = db,
+                                auth             = FirebaseAuth.getInstance(),
+                                sessionId        = sessionId,
+                                questions        = questions,
+                                videoTitle       = videoTitle,
+                                recordedFiles    = recordedFiles,
+                                navController    = navController
+                            )
+                            if (result.isSuccess) {
+                                navController.navigate("${Screen.ResultScreen.route}/$sessionId")
+                            } else {
+                                Toast.makeText(context, "인터뷰 업로드에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                                navController.navigate(Screen.HomeAppl.route)
+                            }
+                        }
                     }) {
                         Text("저장")
                     }
@@ -485,7 +494,7 @@ private fun saveMediapipeResult(
         .addOnFailureListener { e -> Log.e("Mediapipe","저장 실패", e) }
 }
 
-private fun uploadResults(
+suspend fun uploadResults(
     db: FirebaseFirestore,
     auth: FirebaseAuth,
     sessionId: String,
@@ -493,58 +502,64 @@ private fun uploadResults(
     videoTitle: String,
     recordedFiles: List<File>,
     navController: NavController
-) {
-    val storageRef = FirebaseStorage.getInstance().reference
-    CoroutineScope(Dispatchers.IO).launch {
-        try {
-            // 1) 동영상 업로드
-            val videoUrls = mutableListOf<String>()
-            recordedFiles.forEachIndexed { idx, file ->
-                val uri      = Uri.fromFile(file)
-                val videoRef = storageRef.child("videos/$sessionId/${sessionId}_q${idx+1}.mp4")
-                videoRef.putFile(uri).await()
-                videoUrls += videoRef.downloadUrl.await().toString()
-            }
+): Result<Unit> {
+    return try {
+        LoadingState.show("정확한 피드백을 위해 영상을 분석 중입니다.\n1~2분 정도 소요될 수 있어요.")
 
-            // 2) mediapipe 데이터 읽기
-            val mediapipeData = db.collection("interview_mediapipe")
-                .document(sessionId)
-                .get()
-                .await()
-                .data
-                ?: emptyMap<String, Any>()
-
-            // 3) feedback 참조 저장
-            val feedbackRef = db.collection("interview_feedback").document(sessionId)
-
-            val categoryData = mapOf(
-                "major" to "지정 없음",
-                "sub" to "지정 없음"
-            )
-
-            // 4) 인터뷰 문서 저장
-            val videoData = mapOf(
-                "question" to questions,
-                "title" to videoTitle,
-                "category" to categoryData,
-                "uploadTime" to FieldValue.serverTimestamp(),
-                "user" to auth.currentUser?.uid,
-                "videos" to videoUrls.map { mapOf("fileUrl" to it) },
-                "mediapipe" to mediapipeData,
-                "feedback" to feedbackRef,
-                "public" to true
-            )
-            db.collection("interview")
-                .document(sessionId)
-                .set(videoData, SetOptions.merge())
-                .await()
-
-            withContext(Dispatchers.Main) {
-                navController.navigate("${Screen.ResultScreen.route}/$sessionId")
-            }
-        } catch (e: Exception) {
-            Log.e("UploadError", "업로드 실패", e)
+        val storageRef = FirebaseStorage.getInstance().reference
+        // 1) 동영상 업로드
+        val videoUrls = mutableListOf<String>()
+        recordedFiles.forEachIndexed { idx, file ->
+            val uri = Uri.fromFile(file)
+            val videoRef = storageRef.child("videos/$sessionId/${sessionId}_q${idx + 1}.mp4")
+            videoRef.putFile(uri).await()
+            videoUrls += videoRef.downloadUrl.await().toString()
         }
+
+        // 2) mediapipe 데이터 읽기
+        val mediapipeData = db.collection("interview_mediapipe")
+            .document(sessionId)
+            .get()
+            .await()
+            .data
+            ?: emptyMap<String, Any>()
+
+        // 3) feedback 참조 저장
+        val feedbackRef = db.collection("interview_feedback").document(sessionId)
+
+        val categoryData = mapOf(
+            "major" to "지정 없음",
+            "sub" to "지정 없음"
+        )
+
+        // 4) 인터뷰 문서 저장
+        val videoData = mapOf(
+            "question" to questions,
+            "title" to videoTitle,
+            "category" to categoryData,
+            "uploadTime" to FieldValue.serverTimestamp(),
+            "user" to auth.currentUser?.uid,
+            "videos" to videoUrls.map { mapOf("fileUrl" to it) },
+            "mediapipe" to mediapipeData,
+            "feedback" to feedbackRef,
+            "public" to true
+        )
+        db.collection("interview")
+            .document(sessionId)
+            .set(videoData, SetOptions.merge())
+            .await()
+
+        withContext(Dispatchers.Main) {
+            navController.navigate("${Screen.ResultScreen.route}/$sessionId")
+        }
+
+        db.collection("interview").document(sessionId).update("ready", true).await()
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Log.e("UploadError", "업로드 실패", e)
+        Result.failure(e)
+    } finally {
+        LoadingState.hide()
     }
 }
 

--- a/app/src/main/java/com/example/hireapp/screens/applicant/interviewcapture/ResultScreen.kt
+++ b/app/src/main/java/com/example/hireapp/screens/applicant/interviewcapture/ResultScreen.kt
@@ -1,6 +1,7 @@
 @file:OptIn(ExperimentalMaterial3Api::class)
 package com.example.hireapp.screens.applicant.interviewcapture
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -12,11 +13,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.example.hireapp.navigation.Screen
+import com.example.hireapp.util.LoadingState
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
@@ -24,6 +25,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ResultScreen(
     navController: NavController,
@@ -35,11 +37,9 @@ fun ResultScreen(
 
     // 사용자 역할 및 별점 상태
     var userRole by remember { mutableStateOf<String?>(null) }
-    var roleLoading by remember { mutableStateOf(true) }
     var userRating by remember { mutableStateOf<Int?>(null) }
     var averageRating by remember { mutableStateOf(0.0) }
     var ratingsCount by remember { mutableStateOf(0) }
-    var isLoading by remember { mutableStateOf(true) }
     var mediapipeData by remember {
         mutableStateOf<Map<String, Map<String, Map<String, Any>>>>(
             emptyMap()
@@ -50,61 +50,65 @@ fun ResultScreen(
     var answersList by remember { mutableStateOf<List<String>>(emptyList()) }
 
     LaunchedEffect(Unit) {
-        val uid = auth.currentUser?.uid
-        if (uid == null) {
-            navController.navigate("login")
-        } else {
-            try {
-                val doc = db.collection("users").document(uid).get().await()
-                userRole = doc.getString("role")
-            } catch (e: Exception) {
-                userRole = null
+        // 로딩 화면 띄움
+        LoadingState.show("피드백을 불러오는 중입니다.")
+
+        try {
+            val uid = auth.currentUser?.uid
+            if (uid == null) {
+                navController.navigate("login")
+            } else {
+                try {
+                    val doc = db.collection("users").document(uid).get().await()
+                    userRole = doc.getString("role")
+                } catch (e: Exception) {
+                    userRole = null
+                }
             }
+
+            val interviewRef = db.collection("interview").document(sessionId)
+            val interviewDoc = interviewRef.get().await()
+            mediapipeData = interviewDoc.get("mediapipe")
+                    as? Map<String, Map<String, Map<String, Any>>> ?: emptyMap()
+            val rawFb = interviewDoc.get("feedback")
+            val fbRef: DocumentReference? = when (rawFb) {
+                is DocumentReference -> rawFb
+                is String -> db.document(rawFb)
+                else -> null
+            }
+
+            feedbackData = fbRef?.get()?.await()?.data ?: emptyMap()
+
+            val qRef = db.collection("interview_questions").document(sessionId)
+            val qSnap = qRef.get().await()
+            questionsList = (qSnap.get("questions") as? List<*>)
+                ?.mapNotNull { it as? String } ?: emptyList()
+
+            val aRef = db.collection("interview_answers").document(sessionId)
+            val aSnap = aRef.get().await()
+            answersList = (aSnap.get("text") as? List<*>)
+                ?.mapNotNull { it as? String } ?: emptyList()
+
+            // 별점 불러오기
+            val ratingsCol = interviewRef.collection("ratings")
+            if (uid != null) {
+                val myRating = ratingsCol.document(uid).get().await().getLong("rating")?.toInt()
+                userRating = myRating
+            }
+            val allRatings = ratingsCol.get().await().documents
+                .mapNotNull { it.getLong("rating")?.toInt() }
+            ratingsCount = allRatings.size
+            averageRating = if (allRatings.isNotEmpty()) allRatings.average() else 0.0
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Log.d("ResultScreen-Load", "피드백 로드 과정에서 예외 발생")
+        } finally {
+            Log.d("ResultScreen-Load", "피드백 로드 종료")
+            LoadingState.hide()
+            delay(200L)
         }
-        roleLoading = false
     }
 
-    LaunchedEffect(sessionId) {
-        val interviewRef = db.collection("interview").document(sessionId)
-        while (!interviewRef.get().await().exists()) delay(1000L)
-        val interviewDoc = interviewRef.get().await()
-        mediapipeData = interviewDoc.get("mediapipe")
-                as? Map<String, Map<String, Map<String, Any>>> ?: emptyMap()
-        val rawFb = interviewDoc.get("feedback")
-        val fbRef: DocumentReference? = when (rawFb) {
-            is DocumentReference -> rawFb
-            is String -> db.document(rawFb)
-            else -> null
-        }
-        fbRef?.let { ref -> while (!ref.get().await().exists()) delay(1000L) }
-        feedbackData = fbRef?.get()?.await()?.data ?: emptyMap()
-
-        val qRef = db.collection("interview_questions").document(sessionId)
-        while (!qRef.get().await().exists()) delay(1000L)
-        val qSnap = qRef.get().await()
-        questionsList = (qSnap.get("questions") as? List<*>)
-            ?.mapNotNull { it as? String } ?: emptyList()
-
-        val aRef = db.collection("interview_answers").document(sessionId)
-        while (!aRef.get().await().exists()) delay(1000L)
-        val aSnap = aRef.get().await()
-        answersList = (aSnap.get("text") as? List<*>)
-            ?.mapNotNull { it as? String } ?: emptyList()
-
-        // 별점 불러오기
-        val ratingsCol = interviewRef.collection("ratings")
-        val uid = auth.currentUser?.uid
-        if (uid != null) {
-            val myRating = ratingsCol.document(uid).get().await().getLong("rating")?.toInt()
-            userRating = myRating
-        }
-        val allRatings = ratingsCol.get().await().documents
-            .mapNotNull { it.getLong("rating")?.toInt() }
-        ratingsCount = allRatings.size
-        averageRating = if (allRatings.isNotEmpty()) allRatings.average() else 0.0
-
-        isLoading = false
-    }
     fun saveRating(rating: Int) {
         scope.launch {
             val ratingsCol = db.collection("interview").document(sessionId).collection("ratings")
@@ -222,25 +226,6 @@ fun ResultScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            // 로딩 상태 처리
-            if (roleLoading || isLoading) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        modifier = Modifier.padding(16.dp)
-                    ) {
-                        CircularProgressIndicator()
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = "정확한 피드백을 위해 영상을 분석 중입니다.\n1~2분 정도 소요될 수 있어요.",
-                            style = MaterialTheme.typography.bodyMedium,
-                            textAlign = TextAlign.Center
-                        )
-                    }
-                }
-                return@Box
-            }
-
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize(),

--- a/app/src/main/java/com/example/hireapp/screens/interviewer/HomeIntrScreen.kt
+++ b/app/src/main/java/com/example/hireapp/screens/interviewer/HomeIntrScreen.kt
@@ -69,11 +69,13 @@ fun HomeIntrScreen(navController: NavController) {
 
         if(user != null) {
             try {
-                val doc = Firebase.firestore.collection("user").document(user.uid).get().await()
+                val doc = Firebase.firestore.collection("users").document(user.uid).get().await()
 
-                val major = doc.getString("category.major")
-                val sub = doc.getString("category.sub")
+                val categoryMap = doc.get("category") as? Map<*, *>
+                val major = categoryMap?.get("major") as? String ?: "지정 없음"
+                val sub = categoryMap?.get("sub") as? String ?: "지정 없음"
 
+                Log.d("Inter-home", "${categoryMap}")
                 Log.d("Inter-home", "major = ${major}, sub = ${sub}")
 
                 videoList = fetchPublicVideos(

--- a/app/src/main/java/com/example/hireapp/screens/login/SignUpScreen.kt
+++ b/app/src/main/java/com/example/hireapp/screens/login/SignUpScreen.kt
@@ -1,7 +1,9 @@
 package com.example.hireapp.screens.login
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.widget.Toast
+import androidx.annotation.RestrictTo
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -29,11 +31,26 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.ViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import com.example.hireapp.data.Category
+import com.example.hireapp.data.subCategory
+import com.example.hireapp.navigation.Screen
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+class SignUpModel : ViewModel() {
+    var name by mutableStateOf("")
+    var birthDate by mutableStateOf("")
+    var phoneNumber by mutableStateOf("")
+    var email by mutableStateOf("")
+    var password by mutableStateOf("")
+    var role by mutableStateOf("")
+}
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -145,21 +162,24 @@ fun SignUpScreen(navController: NavController) {
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun SignUpCommonScreen(navController: NavController, role: String) {
-    var name by remember { mutableStateOf("") }
-    var birthDate by remember { mutableStateOf("") }
-    var phoneNumber by remember { mutableStateOf("") }
-    var email by remember { mutableStateOf("") }
-    var password by remember { mutableStateOf("") }
+fun SignUpCommonScreen(navController: NavController, viewModel: SignUpModel, role: String) {
+    var name by remember { mutableStateOf(viewModel.name) }
+    var birthDate by remember { mutableStateOf(viewModel.birthDate) }
+    var phoneNumber by remember { mutableStateOf(viewModel.phoneNumber) }
+    var email by remember { mutableStateOf(viewModel.email) }
+    var password by remember { mutableStateOf(viewModel.password) }
     var confirmPassword by remember { mutableStateOf("") }
     var passwordVisible by remember { mutableStateOf(false) }
     var confirmPasswordVisible by remember { mutableStateOf(false) }
 
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     Scaffold {
         Column(
-            modifier = Modifier.fillMaxSize().padding(16.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -221,8 +241,8 @@ fun SignUpCommonScreen(navController: NavController, role: String) {
                 }
             },
                 visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(), modifier = Modifier
-                .fillMaxWidth()
-                .height(60.dp),textStyle = TextStyle(fontSize = 18.sp))
+                    .fillMaxWidth()
+                    .height(60.dp),textStyle = TextStyle(fontSize = 18.sp))
             Spacer(modifier = Modifier.height(8.dp))
             TextField(value = confirmPassword, onValueChange = { confirmPassword = it }, label = { Text("비밀번호 확인") }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password), leadingIcon = {
                 Icon(Icons.Rounded.Lock, contentDescription = "")
@@ -242,8 +262,8 @@ fun SignUpCommonScreen(navController: NavController, role: String) {
                 }
             },
                 visualTransformation = if (confirmPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(), modifier = Modifier
-                .fillMaxWidth()
-                .height(60.dp),textStyle = TextStyle(fontSize = 18.sp))
+                    .fillMaxWidth()
+                    .height(60.dp),textStyle = TextStyle(fontSize = 18.sp))
             Spacer(modifier = Modifier.height(16.dp))
 
             Button(onClick = {
@@ -252,36 +272,32 @@ fun SignUpCommonScreen(navController: NavController, role: String) {
                     return@Button
                 }
 
-                Firebase.auth.createUserWithEmailAndPassword(email, password)
-                    .addOnCompleteListener { task ->
-                        if (task.isSuccessful) {
-                            val user = Firebase.auth.currentUser
-                            val userId = user?.uid ?: ""
-                            val db = Firebase.firestore
-                            val userData = hashMapOf(
-                                "name" to name,
-                                "birthDate" to birthDate,
-                                "phoneNumber" to phoneNumber,
-                                "email" to email,
-                                "role" to role
-                            )
+                if (role == "면접관") {
+                    viewModel.name = name
+                    viewModel.birthDate = birthDate
+                    viewModel.phoneNumber = phoneNumber
+                    viewModel.email = email
+                    viewModel.password = password
+                    viewModel.role = role
 
-                            db.collection("users").document(userId).set(userData)
-                                .addOnSuccessListener {
-                                    Toast.makeText(context, "회원가입이 완료되었습니다.", Toast.LENGTH_SHORT).show()
-                                    if (role == "면접자") {
-                                        navController.navigate("login")
-                                    } else {
-                                        navController.navigate("login") //signup_interviewer 오류나서 login으로 수정
-                                    }
-                                }
-                                .addOnFailureListener { e ->
-                                    Toast.makeText(context, "회원가입에 실패했습니다: ${e.message}", Toast.LENGTH_SHORT).show()
-                                }
-                        } else {
-                            Toast.makeText(context, "회원가입에 실패했습니다: ${task.exception?.message}", Toast.LENGTH_SHORT).show()
+                    navController.navigate(Screen.SignUpInterviewer.route)
+                } else {
+                    scope.launch {
+                        val result = saveUser(
+                            email = email,
+                            password = password,
+                            name = name,
+                            birthDate = birthDate,
+                            phoneNumber = phoneNumber,
+                            role = role
+                        )
+
+                        if (result.isSuccess) {
+                            navController.navigate(Screen.Login.route)
+                            Toast.makeText(context, "회원가입이 완료되었습니다.", Toast.LENGTH_SHORT).show()
                         }
                     }
+                }
             }) {
                 Text(if (role == "면접자") "회원가입 완료" else "다음")
             }
@@ -291,39 +307,17 @@ fun SignUpCommonScreen(navController: NavController, role: String) {
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun SignUpInterviewerScreen(navController: NavController) {
+fun SignUpInterviewerScreen(navController: NavController, viewModel: SignUpModel) {
     var selectedCategory by remember { mutableStateOf<String?>(null) }
     var selectedJob by remember { mutableStateOf<String?>(null) }
 
     val context = LocalContext.current
-    val user = Firebase.auth.currentUser
-    val userId = user?.uid ?: ""
+    val scope = rememberCoroutineScope()
 
-    val categories = listOf(
-        "IT/소프트웨어",
-        "디자인",
-        "마케팅",
-        "영업",
-        "금융",
-        "인사",
-        "의료",
-        "교육",
-        "제조",
-        "법률"
-    )
+    val categories = Category.entries.map{it.label}
+    val subJobsMap = subCategory
 
-    val subJobsMap = mapOf(
-        "IT/소프트웨어" to listOf("프로그래머", "데이터 엔지니어", "AI 전문가"),
-        "디자인" to listOf("UX 디자이너", "그래픽 디자이너", "영상 편집자"),
-        "마케팅" to listOf("디지털 마케터", "브랜드 매니저", "SEO 전문가"),
-        "영업" to listOf("B2B 영업", "해외 영업", "세일즈 매니저"),
-        "금융" to listOf("회계사", "재무 분석가", "투자 컨설턴트"),
-        "인사" to listOf("채용 담당자", "HRBP", "교육 담당자"),
-        "의료" to listOf("의사", "간호사", "물리치료사"),
-        "교육" to listOf("교사", "강사", "콘텐츠 제작자"),
-        "제조" to listOf("기계 엔지니어", "전자 엔지니어", "품질 전문가"),
-        "법률" to listOf("변호사", "법무사", "컨설턴트")
-    )
+    Log.d("SignUp", "면접관 회원가입 시작, sc: ${selectedCategory}, sj: ${selectedJob}")
 
     Scaffold {
         Column(
@@ -358,24 +352,37 @@ fun SignUpInterviewerScreen(navController: NavController) {
             Button(
                 onClick = {
                     if (selectedCategory != null && selectedJob != null) {
-                        val db = Firebase.firestore
-                        val interviewerData = mapOf(
-                            "category" to selectedCategory,
-                            "job" to selectedJob
-                        )
+                        Log.d("SignUp", "면접관 회원가입, sc: ${selectedCategory}, sj: ${selectedJob}")
+                        val major = selectedCategory.toString()
+                        val sub = selectedJob.toString()
 
-                        db.collection("users").document(userId).update(interviewerData)
-                            .addOnSuccessListener {
+                        Log.d("SignUp", "viewModel: ${viewModel.email}, ${viewModel.password}")
+
+                        scope.launch {
+                            val result = saveUser(
+                                email = viewModel.email,
+                                password = viewModel.password,
+                                name = viewModel.name,
+                                birthDate = viewModel.birthDate,
+                                phoneNumber = viewModel.phoneNumber,
+                                role = viewModel.role,
+                                major = major,
+                                sub = sub
+                            )
+
+                            if (result.isSuccess) {
+                                navController.navigate(Screen.Login.route)
                                 Toast.makeText(context, "회원가입이 완료되었습니다.", Toast.LENGTH_SHORT).show()
-                                navController.navigate("login")
+                            } else {
+                                Toast.makeText(context, "회원가입에 실패했습니다.", Toast.LENGTH_SHORT).show()
                             }
-                            .addOnFailureListener { e ->
-                                Toast.makeText(context, "회원가입에 실패했습니다: ${e.message}", Toast.LENGTH_SHORT).show()
-                            }
+                        }
                     }
                 },
                 enabled = selectedCategory != null && selectedJob != null,
-                modifier = Modifier.width(200.dp).height(48.dp)
+                modifier = Modifier
+                    .width(200.dp)
+                    .height(48.dp)
             ) {
                 Text("회원가입 완료")
             }
@@ -430,20 +437,75 @@ fun DropdownMenuWithFixedTextSize(
     }
 }
 
+suspend fun saveUser(
+    email: String,
+    password: String,
+    name: String,
+    birthDate: String,
+    phoneNumber: String,
+    role: String,
+    major: String = "지정 없음",
+    sub: String= "지정 없음"
+    ): Result<Unit> {
+    return try {
+        val authResult = Firebase.auth.createUserWithEmailAndPassword(email, password).await()
+        val user = authResult.user ?: throw Exception("사용자 정보 없음")
+        val userId = user.uid
+        val db = Firebase.firestore
+
+        val userData = mapOf(
+            "name" to name,
+            "birthDate" to birthDate,
+            "phoneNumber" to phoneNumber,
+            "email" to email,
+            "role" to role,
+            "category" to mapOf(
+                "major" to major,
+                "sub" to sub
+            )
+        )
+
+        Log.d("SignUp", "유저데이터: $userData")
+
+        db.collection("users").document(userId).set(userData).await()
+
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Log.e("SignUp", "회원가입 실패: ${e.message}", e)
+        Result.failure(e)
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun PreviewSignUpScreen() {
     SignUpScreen(navController = rememberNavController())
 }
+/*
 
 @Preview(showBackground = true)
 @Composable
 fun PreviewSignUpCommonScreen() {
-    SignUpCommonScreen(navController = rememberNavController(), role = "면접자")
+    val mockViewModel = SignUpModel().apply {
+        name = "example"
+        email = "test@example.com"
+        role = "면접관"
+    }
+
+    SignUpCommonScreen(navController = rememberNavController(), viewModel = mockViewModel, role = "면접자")
 }
 
 @Preview(showBackground = true)
 @Composable
 fun PreviewSignUpInterviewerScreen() {
-    SignUpInterviewerScreen(navController = rememberNavController())
-}
+    val mockViewModel = SignUpModel().apply {
+        name = "example"
+        email = "tester@domain.com"
+        role = "면접관"
+        birthDate = "1995/05/18"
+        phoneNumber = "01012345678"
+        password = "password123"
+    }
+
+    SignUpInterviewerScreen(navController = rememberNavController(), viewModel = mockViewModel)
+}*/


### PR DESCRIPTION
### 기능 추가(복구)
- 면접관 회원가입시 분야 선택 화면 복구
- 피드백 화면 로딩 문구 수정
    : 인터뷰 저장하며 첫 피드백 문서 생성시 인터뷰 문서가 모두 생성되기 전까지 화면이 넘어가지 않도록 수정했습니다. 화면이 넘어가지 않는 동안 기존의 로딩 문구("정확한 피드백을 위해 ... ")가 출력되며, 이후 피드백 문서 화면 로딩에는 다른 문구가 출력됩니다.
- 댓글 작성자 우측에 "대분야 | 소분야" 표시

### 버그 수정
- 면접관 홈화면 필터링에서 users에서 분야를 가져오지 못하던 오류 수정했습니다.
- 댓글 작성시 분야 저장이 null 또는 "지정 없음"으로 되던 부분 수정했습니다.
- 댓글을 불러올 때 분야를 가져오는 필드명을 알맞게 수정했습니다.